### PR TITLE
feat: add budget type

### DIFF
--- a/data/budget/BudgetRespository.js
+++ b/data/budget/BudgetRespository.js
@@ -20,6 +20,7 @@ class BudgetRepository {
       available: budget.amount,
       expenses: [],
       category: budget.category,
+      type: budget.type,
     });
     return createBudget.save();
   }

--- a/db/mongo/budget/budget.schema.js
+++ b/db/mongo/budget/budget.schema.js
@@ -12,6 +12,12 @@ const budgetSchema = new mongoose.Schema({
   amount: { type: Number, required: true },
   description: String,
   available: { type: Number, required: true },
+  type: {
+    type: String,
+    enum: ['NORMAL', 'RESERVE'],
+    default: 'NORMAL',
+    require: true
+  },
   expenses: { type: [ExpenseSchema], default: [] },
   category: { type: String },
 });

--- a/services/budgets/BudgetService.js
+++ b/services/budgets/BudgetService.js
@@ -40,6 +40,7 @@ class BudgetService {
       amount: newBudget.amount,
       description: newBudget.description,
       category: newBudget.category,
+      type: newBudget.type,
     });
   }
 
@@ -64,6 +65,7 @@ class BudgetService {
    * @param {number} attributes.amout
    * @param {string} attributes.description
    * @param {string} attributes.category
+   * @param {string} attributes.type
    * @return {boolean} true if the budget has been udpated, false otherwise
    */
   async patch(budgetId, attributes) {

--- a/services/budgets/BudgetService.test.js
+++ b/services/budgets/BudgetService.test.js
@@ -65,7 +65,7 @@ describe('BudgetService', () => {
   });
 
   describe('create', () => {
-    it('should create a new budget', async () => {
+    it('should create a new budget with default values', async () => {
       const expectedBudget = {
         _id: expect.any(String),
         name: 'BudgetName',
@@ -74,12 +74,39 @@ describe('BudgetService', () => {
         available: 100,
         description: 'budget description',
         expenses: [],
+        type: 'NORMAL'
       };
 
       const budget = await budgetService.create({
         name: expectedBudget.name,
         amount: expectedBudget.amount,
         description: expectedBudget.description,
+      });
+      const storedBudget = await BudgetModelStub.findById(budget._id, []);
+
+      expect(budget).toEqual(expectedBudget);
+      expect(storedBudget).toEqual(expectedBudget);
+    });
+
+    it('should create a new budget with all values', async () => {
+      const expectedBudget = {
+        _id: expect.any(String),
+        name: 'BudgetName',
+        slug: 'budgetname',
+        amount: 100,
+        available: 100,
+        description: 'budget description',
+        expenses: [],
+        category: 'test',
+        type: 'RESERVE'
+      };
+
+      const budget = await budgetService.create({
+        name: expectedBudget.name,
+        amount: expectedBudget.amount,
+        description: expectedBudget.description,
+        category: 'test',
+        type: 'RESERVE',
       });
       const storedBudget = await BudgetModelStub.findById(budget._id, []);
 
@@ -115,6 +142,7 @@ describe('BudgetService', () => {
         description: 'it has been updated',
         category: 'add cat',
         expenses: [],
+        type: 'RESERVE'
       };
 
       await budgetService.patch(budget_id, {
@@ -122,6 +150,7 @@ describe('BudgetService', () => {
         amount: expectedBudget.amount,
         description: expectedBudget.description,
         category: expectedBudget.category,
+        type: expectedBudget.type
       });
 
       const updatedBudget = await BudgetModelStub.findById(budget_id, []);

--- a/test/fixtures/budgetFixture.js
+++ b/test/fixtures/budgetFixture.js
@@ -8,6 +8,7 @@ module.exports = {
       description: "Dépenses liées au contrat d'électricité de la maison",
       available: 58,
       expenses: [],
+      type: 'NORMAL'
     },
     {
       _id: '2',
@@ -17,6 +18,7 @@ module.exports = {
       description: 'Dépenses liées au crédit des voitures',
       available: 369.89,
       expenses: [],
+      type: 'NORMAL'
     },
     {
       _id: '3',
@@ -26,6 +28,7 @@ module.exports = {
       description: 'Dépenses liées au crédit de la maison',
       available: 857.12,
       expenses: [],
+      type: 'NORMAL'
     },
     {
       _id: '4',
@@ -48,6 +51,7 @@ module.exports = {
           date: '2020-08-22',
         },
       ],
+      type: 'NORMAL'
     },
     {
       _id: '5',
@@ -57,6 +61,7 @@ module.exports = {
       description: 'Assurance des voitures',
       available: 127,
       expenses: [],
+      type: 'NORMAL'
     },
     {
       _id: '6',
@@ -66,6 +71,7 @@ module.exports = {
       description: "Dépenses concernant l'alimentation (boucher, laitier, primeur et supermarché)",
       available: 500,
       expenses: [],
+      type: 'NORMAL'
     },
     {
       _id: '7',
@@ -75,6 +81,7 @@ module.exports = {
       description: 'Dépenses pour les chats',
       available: 120,
       expenses: [],
+      type: 'NORMAL'
     },
     {
       _id: '8',
@@ -83,6 +90,7 @@ module.exports = {
       amount: 0,
       available: 0,
       expenses: [],
+      type: 'NORMAL'
     },
   ],
 };

--- a/test/stubs/BudgetModelStub.js
+++ b/test/stubs/BudgetModelStub.js
@@ -2,7 +2,7 @@ const uid = require('uid');
 
 const budgetFixture = require('../fixtures/budgetFixture');
 
-const PATCHABLE_FIELDS = ['name', 'slug', 'amount', 'available', 'description', 'category'];
+const PATCHABLE_FIELDS = ['name', 'slug', 'amount', 'available', 'description', 'category', 'type'];
 
 module.exports = class BudgetModelStub {
   static budgetStore = [];
@@ -13,6 +13,10 @@ module.exports = class BudgetModelStub {
       amount: Number(budget.amount),
       available: Number(budget.available),
     };
+
+    if(this.budget.type === undefined) {
+      this.budget.type = 'NORMAL';
+    }
   }
 
   static resetStore() {


### PR DESCRIPTION
A type is used to split budgets into two categories.
The first one is NORMAL budgets. Budget in this category behaves normally as all simple budgets do. When an expense is added the available amount goes down.
The second category is RESERVE budgets. Budget in this category allows users to accumulate available amount over the months.